### PR TITLE
Gardening.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,190 @@
+#####
+# OS X temporary files that should never be committed
+#
+# c.f. http://www.westwind.com/reference/os-x/invisibles.html
+
+.DS_Store
+
+# c.f. http://www.westwind.com/reference/os-x/invisibles.html
+
+.Trashes
+
+# c.f. http://www.westwind.com/reference/os-x/invisibles.html
+
+*.swp
+
+# *.lock - this is used and abused by many editors for many different things.
+#    For the main ones I use (e.g. Eclipse), it should be excluded
+#    from source-control, but YMMV
+
+*.lock
+
+#
+# profile - REMOVED temporarily (on double-checking, this seems incorrect; I can't find it in OS X docs?)
+#profile
+
+
+####
+# Xcode temporary files that should never be committed
+#
+# NB: NIB/XIB files still exist even on Storyboard projects, so we want this...
+
+*~.nib
+
+
+####
+# Xcode build files -
+#
+# NB: slash on the end, so we only remove the FOLDER, not any files that were badly named "DerivedData"
+
+DerivedData/
+
+# NB: slash on the end, so we only remove the FOLDER, not any files that were badly named "build"
+
+build/
+
+
+#####
+# Xcode private settings (window sizes, bookmarks, breakpoints, custom executables, smart groups)
+#
+# This is complicated:
+#
+# SOMETIMES you need to put this file in version control.
+# Apple designed it poorly - if you use "custom executables", they are
+#  saved in this file.
+# 99% of projects do NOT use those, so they do NOT want to version control this file.
+#  ..but if you're in the 1%, comment out the line "*.pbxuser"
+
+# .pbxuser: http://lists.apple.com/archives/xcode-users/2004/Jan/msg00193.html
+
+*.pbxuser
+
+# .mode1v3: http://lists.apple.com/archives/xcode-users/2007/Oct/msg00465.html
+
+*.mode1v3
+
+# .mode2v3: http://lists.apple.com/archives/xcode-users/2007/Oct/msg00465.html
+
+*.mode2v3
+
+# .perspectivev3: http://stackoverflow.com/questions/5223297/xcode-projects-what-is-a-perspectivev3-file
+
+*.perspectivev3
+
+#    NB: also, whitelist the default ones, some projects need to use these
+!default.pbxuser
+!default.mode1v3
+!default.mode2v3
+!default.perspectivev3
+
+
+####
+# Xcode 4 - semi-personal settings
+#
+#
+# OPTION 1: ---------------------------------
+#     throw away ALL personal settings (including custom schemes!
+#     - unless they are "shared")
+#
+# NB: this is exclusive with OPTION 2 below
+xcuserdata
+
+# OPTION 2: ---------------------------------
+#     get rid of ALL personal settings, but KEEP SOME OF THEM
+#     - NB: you must manually uncomment the bits you want to keep
+#
+# NB: this is exclusive with OPTION 1 above
+#
+#xcuserdata/**/*
+
+#     (requires option 2 above): Personal Schemes
+#
+#!xcuserdata/**/xcschemes/*
+
+####
+# XCode 4 workspaces - more detailed
+#
+# Workspaces are important! They are a core feature of Xcode - don't exclude them :)
+#
+# Workspace layout is quite spammy. For reference:
+#
+# /(root)/
+#   /(project-name).xcodeproj/
+#     project.pbxproj
+#     /project.xcworkspace/
+#       contents.xcworkspacedata
+#       /xcuserdata/
+#         /(your name)/xcuserdatad/
+#           UserInterfaceState.xcuserstate
+#     /xcsshareddata/
+#       /xcschemes/
+#         (shared scheme name).xcscheme
+#     /xcuserdata/
+#       /(your name)/xcuserdatad/
+#         (private scheme).xcscheme
+#         xcschememanagement.plist
+#
+#
+
+####
+# Xcode 4 - Deprecated classes
+#
+# Allegedly, if you manually "deprecate" your classes, they get moved here.
+#
+# We're using source-control, so this is a "feature" that we do not want!
+
+*.moved-aside
+
+####
+# UNKNOWN: recommended by others, but I can't discover what these files are
+#
+# ...none. Everything is now explained.
+
+####
+#
+# Pods and Gems
+#
+/pods
+.bundle/
+
+# Builds
+*.ipa
+
+# ssl certificates
+*.crt
+.idea/.name
+.idea/babylon-partners.iml
+.idea/encodings.xml
+.idea/misc.xml
+.idea/modules.xml
+.idea/runConfigurations/Babylon.xml
+.idea/runConfigurations/BabylonAnalysis.xml
+.idea/scopes/scope_settings.xml
+.idea/vcs.xml
+.idea/workspace.xml
+.idea/xcode.xml
+
+Iconr\n
+Crashlytics.framework
+Crashlytics.framework/
+Crashlytics.*
+Crashlytics
+Babylon/dist/
+dist.zip
+Babylon.xcworkspace
+Babylon.xcworkspace/
+Pods/
 Pods
-ReactiveFeedback.xcworkspace/xcuserdata
+
+# Orig files skipped
+*.orig
+
+Carthage/Checkouts/*
+backboneLocalizationBuilder
+.idea/babylon-ios.iml
+.idea/runConfigurations/Babylon_STAGING1.xml
+
+# Fastlane
+fastlane/README.md
+fastlane/report.xml
+vendor/

--- a/Example/PaginationViewController.swift
+++ b/Example/PaginationViewController.swift
@@ -89,11 +89,9 @@ final class PaginationViewModel {
             Feedbacks.retryPagingFeedback()
         ]
         let initialState = State.initial
-        let stateProducer = SignalProducer<State, NoError>.system(
-                initialState: initialState,
-                reduce: State.reduce,
-                feedback: feedbacks
-            )
+        let stateProducer = SignalProducer.system(initial: initialState,
+                                                  reduce: State.reduce,
+                                                  feedbacks: feedbacks)
             .observe(on: QueueScheduler.main)
 
         let stateProperty = Property<State>(initial: initialState, then: stateProducer)

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -56,9 +56,9 @@ final class ViewModel {
                 return decrement.map { _ in Event.decrement }
         }
 
-        let state = SignalProducer<Int, NoError>.system(initialState: 0,
-                                                        reduce: IncrementReducer.reduce,
-                                                        feedback: incrementFeedback, decrementFeedback)
+        let state = SignalProducer.system(initial: 0,
+                                          reduce: IncrementReducer.reduce,
+                                          feedbacks: incrementFeedback, decrementFeedback)
             .map(String.init)
 
         self.counter = Property(initial: "", then: state)

--- a/ReactiveFeedback/Sources/FeedbackLoops.swift
+++ b/ReactiveFeedback/Sources/FeedbackLoops.swift
@@ -3,45 +3,56 @@ import ReactiveSwift
 import enum Result.NoError
 
 public struct FeedbackLoop<State, Event> {
-    let loop: (Scheduler, Signal<State, NoError>) -> Signal<Event, NoError>
+    public let loop: (Scheduler, Signal<State, NoError>) -> Signal<Event, NoError>
 
-    public init<Control:Equatable, Effect:SignalProducerConvertible>(query: @escaping (State) -> Control?,
-                                                                     effects: @escaping (Control) -> Effect) where Effect.Error == NoError, Effect.Value == Event {
-        self.loop = { (scheduler, state) in
-            return state.map(query)
+    public init<Control: Equatable, Effect: SignalProducerConvertible>(
+        query: @escaping (State) -> Control?,
+        effects: @escaping (Control) -> Effect
+    ) where Effect.Value == Event, Effect.Error == NoError {
+        self.loop = { scheduler, state in
+            return state
+                .map(query)
                 .skipRepeats { $0 == $1 }
                 .flatMap(.latest) { control -> SignalProducer<Event, NoError> in
-                    guard let control = control else { return SignalProducer<Event, NoError>.empty }
+                    guard let control = control else { return .empty }
                     return effects(control).producer
                         .enqueue(on: scheduler)
                 }
         }
     }
 
-    public init<Control, Effect:SignalProducerConvertible>(query: @escaping (State) -> Control?,
-                                                           effects: @escaping (Control) -> Effect) where Effect.Error == NoError, Effect.Value == Event {
-        self.loop = { (scheduler, state) in
-            return state.map(query)
+    public init<Control, Effect: SignalProducerConvertible>(
+        query: @escaping (State) -> Control?,
+        effects: @escaping (Control) -> Effect
+    ) where Effect.Value == Event, Effect.Error == NoError {
+        self.loop = { scheduler, state in
+            return state
+                .map(query)
                 .flatMap(.latest) { control -> SignalProducer<Event, NoError> in
-                    guard let control = control else { return SignalProducer<Event, NoError>.empty }
+                    guard let control = control else { return .empty }
                     return effects(control).producer
                         .enqueue(on: scheduler)
                 }
         }
     }
 
-    public init<Effect:SignalProducerConvertible>(predicate: @escaping (State) -> Bool,
-                                                  effects: @escaping (State) -> Effect) where Effect.Error == NoError, Effect.Value == Event {
-        self.loop = { (scheduler, state) in
-            return state.flatMap(.latest) { state -> SignalProducer<Event, NoError> in
-                guard predicate(state) else { return SignalProducer<Event, NoError>.empty }
-                return effects(state).producer
-                    .enqueue(on: scheduler)
+    public init<Effect: SignalProducerConvertible>(
+        predicate: @escaping (State) -> Bool,
+        effects: @escaping (State) -> Effect
+    ) where Effect.Value == Event, Effect.Error == NoError {
+        self.loop = { scheduler, state in
+            return state
+                .flatMap(.latest) { state -> SignalProducer<Event, NoError> in
+                    guard predicate(state) else { return .empty }
+                    return effects(state).producer
+                        .enqueue(on: scheduler)
             }
         }
     }
 
-    public init<Effect:SignalProducerConvertible>(effects: @escaping (State) -> Effect) where Effect.Error == NoError, Effect.Value == Event {
+    public init<Effect: SignalProducerConvertible>(
+        effects: @escaping (State) -> Effect
+    ) where Effect.Value == Event, Effect.Error == NoError {
         self.loop = { scheduler, state in
             return state.flatMap(.latest) { state -> SignalProducer<Event, NoError> in
                 return effects(state).producer
@@ -51,7 +62,7 @@ public struct FeedbackLoop<State, Event> {
     }
 }
 
-extension SignalProducer {
+fileprivate extension SignalProducer {
     func enqueue(on scheduler: Scheduler) -> SignalProducer<Value, Error> {
         return start(on: scheduler)
             .observe(on: scheduler)


### PR DESCRIPTION
Pull in `.gitignore` from our own mainline repo.
Break function signatures that go beyond 90 characters.
Tweaked the argument labels of `SignalProducer.system`.

fixes #8