### PR TITLE
Fix the Result project path.

### DIFF
--- a/ReactiveFeedback.xcworkspace/contents.xcworkspacedata
+++ b/ReactiveFeedback.xcworkspace/contents.xcworkspacedata
@@ -5,7 +5,7 @@
       location = "container:"
       name = "Dependencies">
       <FileRef
-         location = "group:Carthage/Checkouts/Result/Result.xcodeproj">
+         location = "group:Carthage/Checkouts/ReactiveSwift/Carthage/Checkouts/Result/Result.xcodeproj">
       </FileRef>
       <FileRef
          location = "group:Carthage/Checkouts/ReactiveSwift/ReactiveSwift.xcodeproj">


### PR DESCRIPTION
Carthage does not checkout nested dependencies at the root `Carthage/Checkouts/` folder.