### PR TITLE
Public `Feedback` primitive initialiser.

### DIFF
--- a/ReactiveFeedback/Feedback.swift
+++ b/ReactiveFeedback/Feedback.swift
@@ -4,6 +4,10 @@ import enum Result.NoError
 
 public struct Feedback<State, Event> {
     public let events: (Scheduler, Signal<State, NoError>) -> Signal<Event, NoError>
+    
+    public init(events: @escaping (Scheduler, Signal<State, NoError>) -> Signal<Event, NoError>) {
+        self.events = events
+    }
 
     public init<Control: Equatable, Effect: SignalProducerConvertible>(
         query: @escaping (State) -> Control?,


### PR DESCRIPTION
This initialiser is useful when one has event sources that should stay alive across multiple states.