### PR TITLE
Let feedback effects start immediately.

### DIFF
--- a/ReactiveFeedback/Feedback.swift
+++ b/ReactiveFeedback/Feedback.swift
@@ -30,7 +30,7 @@ public struct Feedback<State, Event> {
                 .flatMap(.latest) { control -> SignalProducer<Event, NoError> in
                     guard let control = control else { return .empty }
                     return effects(control).producer
-                        .enqueue(on: scheduler)
+                        .observe(on: scheduler)
                 }
         }
     }
@@ -51,7 +51,7 @@ public struct Feedback<State, Event> {
                 .flatMap(.latest) { control -> SignalProducer<Event, NoError> in
                     guard let control = control else { return .empty }
                     return effects(control).producer
-                        .enqueue(on: scheduler)
+                        .observe(on: scheduler)
                 }
         }
     }
@@ -69,7 +69,7 @@ public struct Feedback<State, Event> {
             return state.filter(predicate)
                 .flatMap(.latest) { state -> SignalProducer<Event, NoError> in
                     return effects(state).producer
-                        .enqueue(on: scheduler)
+                        .observe(on: scheduler)
             }
         }
     }
@@ -83,7 +83,7 @@ public struct Feedback<State, Event> {
         self.events = { scheduler, state in
             return state.flatMap(.latest) { state -> SignalProducer<Event, NoError> in
                 return effects(state).producer
-                    .enqueue(on: scheduler)
+                    .observe(on: scheduler)
             }
         }
     }

--- a/ReactiveFeedback/SignalProducer+System.swift
+++ b/ReactiveFeedback/SignalProducer+System.swift
@@ -56,9 +56,4 @@ extension SignalProducer where Error == NoError {
     private static func deferred(_ producer: @escaping () -> SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
         return SignalProducer { $1 += producer().start($0) }
     }
-
-    func enqueue(on scheduler: Scheduler) -> SignalProducer<Value, Error> {
-        return producer.start(on: scheduler)
-            .observe(on: scheduler)
-    }
 }


### PR DESCRIPTION
The signal recursion deadlock happens to the new state signal only when we deliver new events synchronously. New events have already been made asynchronous by `observe(on:)`, which renders `start(on:)` unnecessary in the course of breaking signal recursion.

This also makes the behaviour of the system producer (and its `Property` initialiser variant) a bit more predictable, in the sense that we can be sure all the feedbacks are started right in place, instead of scheduled asynchronously. This can be important when used in conjunction with timing-sensitive hot `Signal`s.

Thanks @p4checo for questioning its necessity.