### PR TITLE
New Feedback `init` driven by external control signal

### DIFF
--- a/ReactiveFeedback/Feedback.swift
+++ b/ReactiveFeedback/Feedback.swift
@@ -100,12 +100,12 @@ public struct Feedback<State, Event> {
     public init<Control>(control: Signal<Control, NoError>, effect: @escaping (Control, State) -> Event?) {
         self.events = { scheduler, state in
             control
+                .observe(on: scheduler)
                 .withLatest(from: state)
                 .flatMap(.latest) { control, state -> SignalProducer<Event, NoError> in
                     guard let event = effect(control, state) else { return .empty }
                     return SignalProducer(value: event)
                 }
-                .observe(on: scheduler)
         }
     }
 }

--- a/ReactiveFeedback/Feedback.swift
+++ b/ReactiveFeedback/Feedback.swift
@@ -87,4 +87,25 @@ public struct Feedback<State, Event> {
             }
         }
     }
+
+    /// Creates a Feedback which will perform an effect for each value sent by `control` when the provided `effect`
+    /// closure returns non `nil`. Otherwise, it cancels any previously performed ones. The Feedback's latest state is
+    /// captured for each control value that is received, and used in the `effect` closure.
+    ///
+    /// - parameters:
+    ///    - control: A sequence of controls that is fed into the `effect` closure together with the latest `State` to
+    /// produce effects
+    ///    - effect: A closure which transforms the `Control` and `State` into an `Event` (or `nil`) that mutates the
+    /// `State`
+    public init<Control>(control: Signal<Control, NoError>, effect: @escaping (Control, State) -> Event?) {
+        self.events = { scheduler, state in
+            control
+                .withLatest(from: state)
+                .flatMap(.latest) { control, state -> SignalProducer<Event, NoError> in
+                    guard let event = effect(control, state) else { return .empty }
+                    return SignalProducer(value: event)
+                }
+                .observe(on: scheduler)
+        }
+    }
 }


### PR DESCRIPTION
# Motivation 

When state transitions are to be triggered from external events (e.g. reacting to user interaction, notification, etc) via `Signal`'s, all existing `init`s except the "raw" `init(effects:)` use the system's `state` signal as the "driver" of the `events` chain.

When used with the previous `init`s, these external events can be processed "out of sync" by the system from a time perspective, because when the `query` or `predicate` "passes" (i.e. it returns a non `nil` `Control` or `true`) but the inner `Effect` still hasn't produced a value, the chain will block until a value is returned by the external signal.

On some cases, the `Effect` might not even make sense anymore, because by that time other state transitions might already have occurred, and the `query`/`predicate` of the Feedback wouldn't "pass" under the current state anymore. Since they have already passed on the chain, the `Effect` is processed anyway, which will result in essentially an invalid event (and possibly transition).

For these scenarios, it appears that the external signal should be the "driver" of the `events` chain, so that whenever it fires a control value, the current system's state is captured, and both values are then
evaluated using a closure (similar to `query`) that produces a new effect (`Event`), or cancels any previous one.

To address this, a new `init(control:effect:)` was created on `Feedback` to provide this behavior.

## Notes

Haven't added any tests or additional documentation because I would like gather some input from you guys first, to know if these changes make sense at all, and don't go against the Feedback "concept" 😉