### PR TITLE
Refactor to Allow Explicit Inputs.

### DIFF
--- a/Example/PaginationViewController.swift
+++ b/Example/PaginationViewController.swift
@@ -88,13 +88,13 @@ final class PaginationViewModel {
             Feedbacks.retryPagingFeedback()
         ]
 
-        let input = Feedback.InputCollection.empty()
+        let inputs = Feedback.InputCollection.empty()
             .add(Inputs.nearBottomInput(for: nearBottomSignal))
             .add(Inputs.retryInput(for: retrySignal))
 
-        let system: SignalProducer<State, NoError> = .system(input: input,
+        let system: SignalProducer<State, NoError> = .system(input: inputs,
                                                              initial: State.initial,
-        scheduler: UIScheduler(),
+                                                             scheduler: UIScheduler(),
                                                              reduce: State.reduce,
                                                              feedbacks: feedbacks)
 

--- a/ReactiveFeedback.xcodeproj/project.pbxproj
+++ b/ReactiveFeedback.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		9AFA21261F9511A5001DBF7C /* ReactiveFeedback.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 9AFA21251F9511A5001DBF7C /* ReactiveFeedback.podspec */; };
 		A950943401765BB90FA846B2 /* SignalProducer+System.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9509880213192F0D80EC2B3 /* SignalProducer+System.swift */; };
 		A9509BE4551098F4A5503820 /* Feedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95097E70D3CBFF05FA7B8CC /* Feedback.swift */; };
+		BABEC3C721831F1300A1AF8E /* Input.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABEC3C621831F1300A1AF8E /* Input.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -166,6 +167,7 @@
 		9AFA21251F9511A5001DBF7C /* ReactiveFeedback.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = ReactiveFeedback.podspec; sourceTree = "<group>"; };
 		A95097E70D3CBFF05FA7B8CC /* Feedback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Feedback.swift; sourceTree = "<group>"; };
 		A9509880213192F0D80EC2B3 /* SignalProducer+System.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SignalProducer+System.swift"; sourceTree = "<group>"; };
+		BABEC3C621831F1300A1AF8E /* Input.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Input.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -248,6 +250,7 @@
 			isa = PBXGroup;
 			children = (
 				A95097E70D3CBFF05FA7B8CC /* Feedback.swift */,
+				BABEC3C621831F1300A1AF8E /* Input.swift */,
 				A9509880213192F0D80EC2B3 /* SignalProducer+System.swift */,
 				9AD5D42C1F97375E00E6AE5A /* Property+System.swift */,
 				25CC87B11F92855300A6EBFC /* Info.plist */,
@@ -590,6 +593,7 @@
 			files = (
 				A9509BE4551098F4A5503820 /* Feedback.swift in Sources */,
 				A950943401765BB90FA846B2 /* SignalProducer+System.swift in Sources */,
+				BABEC3C721831F1300A1AF8E /* Input.swift in Sources */,
 				9AD5D42D1F97375E00E6AE5A /* Property+System.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ReactiveFeedback/Input.swift
+++ b/ReactiveFeedback/Input.swift
@@ -4,7 +4,7 @@ import Result
 public protocol FeedbackInputSignal {
     associatedtype State
     associatedtype Event
-    func input(state: Property<State>) -> Signal<Event, NoError>
+    func input(state: Property<State>, scheduler: Scheduler) -> Signal<Event, NoError>
 }
 
 extension Feedback {
@@ -12,31 +12,40 @@ extension Feedback {
     public struct Input<ExternalEvent>: FeedbackInputSignal {
         let inputEvents: Signal<ExternalEvent, NoError>
         let inputReducer: (State, ExternalEvent) -> Event?
-        let scheduler: Scheduler
 
-        public func input(state: Property<State>) -> Signal<Event, NoError> {
+        public func input(state: Property<State>, scheduler: Scheduler) -> Signal<Event, NoError> {
             return inputEvents.observe(on: scheduler).map {
                 self.inputReducer(state.value, $0)
             }.skipNil()
         }
 
         public init(inputEvents: Signal<ExternalEvent, NoError>,
-                    inputReducer: @escaping (State, ExternalEvent) -> Event?,
-                    scheduler: Scheduler) {
+                    inputReducer: @escaping (State, ExternalEvent) -> Event?) {
             self.inputEvents = inputEvents
             self.inputReducer = inputReducer
-            self.scheduler = scheduler
         }
     }
 
     public struct InputCollection: FeedbackInputSignal {
-        private var inputFunctions: [(Property<State>) -> Signal<Event, NoError>]
+        private var inputFunctions: [(Property<State>, Scheduler) -> Signal<Event, NoError>]
 
-        public func input(state: Property<State>) -> Signal<Event, NoError> {
-            return .merge(inputFunctions.map { $0(state) })
+        public func input(state: Property<State>, scheduler: Scheduler) -> Signal<Event, NoError> {
+            return .merge(inputFunctions.map { $0(state, scheduler) })
         }
 
-        public mutating func add<InputSignal>(input: InputSignal) -> Void
+        public static func empty() -> InputCollection { return self.init(inputFunctions: []) }
+
+        public func add<InputSignal>(_ input: InputSignal) -> InputCollection
+            where InputSignal: FeedbackInputSignal,
+            InputSignal.State == State,
+            InputSignal.Event == Event {
+                var inputFunctions = self.inputFunctions
+                inputFunctions.append(input.input)
+
+                return InputCollection(inputFunctions: inputFunctions)
+        }
+
+        public mutating func add<InputSignal>(_ input: InputSignal) -> Void
             where InputSignal: FeedbackInputSignal,
             InputSignal.State == State,
             InputSignal.Event == Event {

--- a/ReactiveFeedback/Input.swift
+++ b/ReactiveFeedback/Input.swift
@@ -1,0 +1,46 @@
+import ReactiveSwift
+import Result
+
+public protocol FeedbackInputSignal {
+    associatedtype State
+    associatedtype Event
+    func input(state: Property<State>) -> Signal<Event, NoError>
+}
+
+extension Feedback {
+
+    public struct Input<ExternalEvent>: FeedbackInputSignal {
+        let inputEvents: Signal<ExternalEvent, NoError>
+        let inputReducer: (State, ExternalEvent) -> Event?
+        let scheduler: Scheduler
+
+        public func input(state: Property<State>) -> Signal<Event, NoError> {
+            return inputEvents.observe(on: scheduler).map {
+                self.inputReducer(state.value, $0)
+            }.skipNil()
+        }
+
+        public init(inputEvents: Signal<ExternalEvent, NoError>,
+                    inputReducer: @escaping (State, ExternalEvent) -> Event?,
+                    scheduler: Scheduler) {
+            self.inputEvents = inputEvents
+            self.inputReducer = inputReducer
+            self.scheduler = scheduler
+        }
+    }
+
+    public struct InputCollection: FeedbackInputSignal {
+        private var inputFunctions: [(Property<State>) -> Signal<Event, NoError>]
+
+        public func input(state: Property<State>) -> Signal<Event, NoError> {
+            return .merge(inputFunctions.map { $0(state) })
+        }
+
+        public mutating func add<InputSignal>(input: InputSignal) -> Void
+            where InputSignal: FeedbackInputSignal,
+            InputSignal.State == State,
+            InputSignal.Event == Event {
+                inputFunctions.append(input.input)
+        }
+    }
+}

--- a/ReactiveFeedback/SignalProducer+System.swift
+++ b/ReactiveFeedback/SignalProducer+System.swift
@@ -70,7 +70,8 @@ extension SignalProducer where Error == NoError {
             return feedback.events(scheduler, state)
         }
 
-        events.append(input.input(state: Property(initial: initial, then: state)))
+        events.append(input.input(state: Property(initial: initial, then: state),
+                                  scheduler: scheduler))
 
         return SignalProducer<Event, NoError>(Signal.merge(events))
             .scan(initial, reduce)

--- a/ReactiveFeedback/SignalProducer+System.swift
+++ b/ReactiveFeedback/SignalProducer+System.swift
@@ -53,6 +53,20 @@ extension SignalProducer where Error == NoError {
         return system(initial: initial, reduce: reduce, feedbacks: feedbacks)
     }
 
+    public static func inputSystem<Event, InputSignal>(
+        input: InputSignal,
+        initial: Value,
+        scheduler: Scheduler = QueueScheduler.main,
+        reduce: @escaping (Value, Event) -> Value,
+        feedbacks: [Feedback<Value, Event>]
+        ) -> SignalProducer<Value, NoError> where
+        InputSignal: FeedbackInputSignal,
+        InputSignal.Event == Event,
+        InputSignal.State == Value
+    {
+        return system(initial: initial, scheduler:scheduler, reduce: reduce, feedbacks: feedbacks)
+    }
+
     private static func deferred(_ producer: @escaping () -> SignalProducer<Value, Error>) -> SignalProducer<Value, Error> {
         return SignalProducer { $1 += producer().start($0) }
     }


### PR DESCRIPTION
Current production code tend to subscribe to external inputs in a way that is slightly awkward. In this example from the demo app it is quite difficult to reason about when the `startLoadingNextPage` event will fire.

```
   Feedback(predicate: { !$0.paging }) { _ in
                  nearBottomSignal.map { Event.startLoadingNextPage }
   }
```

I propose that we resolve this by adding explicit inputs which listen to an external input. When an input is received they evaluate a function `(State, InputEvent) -> Event?` which models if and how the system should react to an `InputEvent` given its current `State`.

This code would need a bit of tidying up before being merged, but I would appreciate feedback on whether explicit inputs is considered to be a good design and if the proposed implementation can be improved.

❤️ 
@zzcgumn 