### PR TITLE
Fix a race condition when a system is started on a different queue from its event serialising queue.

### DIFF
--- a/ReactiveFeedback/SignalProducer+System.swift
+++ b/ReactiveFeedback/SignalProducer+System.swift
@@ -29,8 +29,23 @@ extension SignalProducer where Error == NoError {
 
             return SignalProducer<Event, NoError>(Signal.merge(events))
                 .scan(initial, reduce)
-                .prefix(value: initial)
                 .on(value: stateObserver.send(value:))
+                .prefix(value: initial)
+                .on(started: {
+                    // NOTE: Due to the nature of `prefix` lazily starting the producer being prefixed, we cannot rely
+                    //       on `on(value:)` to ignite the feedbacks with the initial state.
+                    //
+                    //       At the time `prefix(value:)` calls `on(value:)` for the initial value, the events-reducer
+                    //       producer has not yet been started yet. Consequentially, it would lead to dropped events
+                    //       when the system is instantiated on a queue different from the queue used for
+                    //       serializing events.
+                    //
+                    //       Having said that, `prefix(value:)` is guaranteed to have started the prefixed producer as
+                    //       part of the synchronous producer starting process. So we can address the issue by applying
+                    //       `on(started:)` after `prefix(value:)` to ignite the system, while having `on(value:)`
+                    //       instead applied before `prefix(value:)` to keep the reducer-to-feedbacks path open.
+                    stateObserver.send(value: initial)
+                })
         }
     }
 

--- a/ReactiveFeedback/SignalProducer+System.swift
+++ b/ReactiveFeedback/SignalProducer+System.swift
@@ -29,23 +29,25 @@ extension SignalProducer where Error == NoError {
 
             return SignalProducer<Event, NoError>(Signal.merge(events))
                 .scan(initial, reduce)
-                .on(value: stateObserver.send(value:))
+                .on(
+                    started: {
+                        // NOTE: Due to the nature of `prefix` lazily starting the producer being prefixed, we cannot rely
+                        //       on `on(value:)` to ignite the feedbacks with the initial state.
+                        //
+                        //       At the time `prefix(value:)` calls `on(value:)` for the initial value, the events-reducer
+                        //       producer has not yet been started yet. Consequentially, it would lead to dropped events
+                        //       when the system is instantiated on a queue different from the queue used for
+                        //       serializing events.
+                        //
+                        //       Having said that, `prefix(value:)` is guaranteed to have started the prefixed producer as
+                        //       part of the synchronous producer starting process. So we can address the issue by applying
+                        //       `on(started:)` after `prefix(value:)` to ignite the system, while having `on(value:)`
+                        //       instead applied before `prefix(value:)` to keep the reducer-to-feedbacks path open.
+                        stateObserver.send(value: initial)
+                    },
+                    value: stateObserver.send(value:)
+                )
                 .prefix(value: initial)
-                .on(started: {
-                    // NOTE: Due to the nature of `prefix` lazily starting the producer being prefixed, we cannot rely
-                    //       on `on(value:)` to ignite the feedbacks with the initial state.
-                    //
-                    //       At the time `prefix(value:)` calls `on(value:)` for the initial value, the events-reducer
-                    //       producer has not yet been started yet. Consequentially, it would lead to dropped events
-                    //       when the system is instantiated on a queue different from the queue used for
-                    //       serializing events.
-                    //
-                    //       Having said that, `prefix(value:)` is guaranteed to have started the prefixed producer as
-                    //       part of the synchronous producer starting process. So we can address the issue by applying
-                    //       `on(started:)` after `prefix(value:)` to ignite the system, while having `on(value:)`
-                    //       instead applied before `prefix(value:)` to keep the reducer-to-feedbacks path open.
-                    stateObserver.send(value: initial)
-                })
         }
     }
 


### PR DESCRIPTION
Resolve #37.

## Why?
Due to the nature of `prefix` lazily starting the producer being prefixed, we cannot rely on `on(value:)` to ignite the feedbacks with the initial state. At the time `prefix(value:)` calls `on(value:)` for the initial value, the events-reducer producer has not yet been started yet. Consequentially, it would lead to dropped events when the system is instantiated on a queue different from the queue used for serializing events.
         
## Explanation

The current operator application order is `prefix(value:)` followed by `on(value:)`.

Recall that `prefix(value:)` is essentially `a concat b`. Since `b` would not start before `a` completes, the `events -> reducer` part is not started until `a` has finished sending out the prefix value.

When `prefix(value:)` sends out the initial value, `on(value:)` sends the initial value to the state signal, which in turn updates all feedback signals. But since the events-reducer producer hasn’t started yet (which is the `flatMap(.concat)` semantic), all events generated by feedbacks could potentially be delivered to the void, when the queue instantiating the system runs behind the queue serialising all feedback events.

## How to fix it?

Having said that, `prefix(value:)` is guaranteed to have started the prefixed producer as part of the synchronous producer starting process. So we can address the issue by applying `on(started:)` after `prefix(value:)` to ignite the system, while having `on(value:)` applied instead before `prefix(value:)` to still keep the reducer-to-feedbacks path open.