### PR TITLE
Add event-driven `Feedback` (optional event as workaround)

### DIFF
--- a/ReactiveFeedback/Feedback.swift
+++ b/ReactiveFeedback/Feedback.swift
@@ -13,14 +13,21 @@ public struct Feedback<State, Event> {
     /// - parameters:
     ///   - events: The transform which derives a `Signal` of events from the
     ///             latest state.
-    public init(events: @escaping (Scheduler, Signal<(Event?, State), NoError>) -> Signal<Event, NoError>) {
+    public init(events: @escaping (Scheduler, Signal<(Event?, State), NoError>) -> Signal<Event, NoError>, _ dummy: Void = ()) {
         self.events = events
     }
 
+    /// Creates an arbitrary Feedback, which evaluates side effects reactively
+    /// to the latest state, and eventually produces events that affect the
+    /// state.
+    ///
+    /// - parameters:
+    ///   - events: The transform which derives a `Signal` of events from the
+    ///             latest state.
     public init(events: @escaping (Scheduler, Signal<State, NoError>) -> Signal<Event, NoError>) {
-        self.init { scheduler, signal -> Signal<Event, NoError> in
+        self.init(events: { scheduler, signal -> Signal<Event, NoError> in
             return events(scheduler, signal.map { $1 })
-        }
+        })
     }
 
     /// Creates a Feedback which re-evaluates the given effect every time the


### PR DESCRIPTION
This is an **additive change** to add `Optional<Event>` argument in `Feedback` so that unnecessary intermediate states will no longer be required.

Event-driven feedback will be useful for following scenarios, without needing to add a new state and then transit (and transit back again):
 
- Logging
- Analytics
- Routing
- Image loader (but not managing its internal states)

This is a change **from Moore model to (kind of) Mealy model** as discussed in https://github.com/Babylonpartners/ReactiveFeedback/pull/32#pullrequestreview-218703551 .

Please note that `reducer` and `feedback` are still in sequence, not parallel.

Also, please note that `Optional<Event>` is used here as a workaround since it requires more breaking changes to minimize into non-optional `Event`.