### PR TITLE
Fixes bug when failing predicate was not stoping reducer to be executed

### DIFF
--- a/ReactiveFeedback/Feedback.swift
+++ b/ReactiveFeedback/Feedback.swift
@@ -94,8 +94,10 @@ public struct Feedback<State, Event> {
         predicate: @escaping (State) -> Bool,
         effects: @escaping (State) -> Effect
     ) where Effect.Value == Event, Effect.Error == NoError {
-        self.init(deriving: { $0.filter(predicate) },
-                  effects: effects)
+        self.init(deriving: { $0 },
+                  effects: { state -> SignalProducer<Event, NoError> in
+                      predicate(state) ? effects(state).producer : .empty                      
+                  })
     }
 
     /// Creates a Feedback which re-evaluates the given effect every time the

--- a/ReactiveFeedbackTests/SystemTests.swift
+++ b/ReactiveFeedbackTests/SystemTests.swift
@@ -216,4 +216,48 @@ class SystemTests: XCTestCase {
         semaphore.wait()
         expect(observedState.value).toEventually(equal(["initial", "initial_event"]))
     }
+
+    func test_predicate_prevents_state_updates() {
+        enum Event {
+            case increment
+        }
+        let (incrementSignal, incrementObserver) = Signal<Void, NoError>.pipe()
+        let feedback = Feedback<Int, Event>(predicate: { $0 < 2 }) { _ in
+            incrementSignal.map { _ in Event.increment }
+        }
+        let system = SignalProducer<Int, NoError>.system(
+            initial: 0,
+            reduce: { (state: Int, event: Event) in
+                switch event {
+                case .increment:
+                    return state + 1
+                }
+            },
+            feedbacks: [feedback])
+
+        let (lifetime, token) = Lifetime.make()
+
+        var result: [Int]!
+        system.take(during: lifetime)
+            .collect()
+            .startWithValues {
+                result = $0
+            }
+
+        func increment(numberOfTimes: Int) {
+            guard numberOfTimes > 0 else {
+                token.dispose()
+                return
+            }
+            DispatchQueue.main.async {
+                incrementObserver.send(value: ())
+                increment(numberOfTimes: numberOfTimes - 1)
+            }
+        }
+        increment(numberOfTimes: 3)
+
+        let expected = [0, 1, 2]
+
+        expect(result).toEventually(equal(expected))
+    }
 }

--- a/ReactiveFeedbackTests/SystemTests.swift
+++ b/ReactiveFeedbackTests/SystemTests.swift
@@ -246,7 +246,7 @@ class SystemTests: XCTestCase {
 
         func increment(numberOfTimes: Int) {
             guard numberOfTimes > 0 else {
-                token.dispose()
+                DispatchQueue.main.async { token.dispose() }
                 return
             }
             DispatchQueue.main.async {
@@ -254,7 +254,7 @@ class SystemTests: XCTestCase {
                 increment(numberOfTimes: numberOfTimes - 1)
             }
         }
-        increment(numberOfTimes: 3)
+        increment(numberOfTimes: 7)
 
         let expected = [0, 1, 2]
 


### PR DESCRIPTION
When playing with example I discovered that predicate is not applied when tapping plus button multiple times.
I did fix that issue and implement test which is covering that case.