### PR TITLE
Anders/new feedback variant

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 references:
     - &container_config
         macos:
-            xcode: "10.3.0"
+            xcode: "11.3.0"
         working_directory: /Users/distiller/project
         shell: /bin/bash --login -eo pipefail
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ workflows:
         jobs:
             - checkout_code
             - test:
-                parameters: iphonesimulator "platform=iOS Simulator,name=iPhone X" ReactiveFeedback-iOS
+                parameters: iphonesimulator "platform=iOS Simulator,name=iPhone 11" ReactiveFeedback-iOS
                 name: Test-iOS
                 requires:
                     - checkout_code
@@ -132,7 +132,7 @@ workflows:
                 requires:
                     - checkout_code
             - test:
-                parameters: iphonesimulator "platform=iOS Simulator,name=iPhone X" Example build
+                parameters: iphonesimulator "platform=iOS Simulator,name=iPhone 11" Example build
                 name: ExampleApp
                 requires:
                     - checkout_code

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Quick/Nimble" "v8.0.4"
-github "ReactiveCocoa/ReactiveCocoa" "10.0.0"
-github "ReactiveCocoa/ReactiveSwift" "6.1.0"
-github "onevcat/Kingfisher" "5.7.1"
+github "Quick/Nimble" "v8.0.5"
+github "ReactiveCocoa/ReactiveCocoa" "10.2.0"
+github "ReactiveCocoa/ReactiveSwift" "6.2.0"
+github "onevcat/Kingfisher" "5.13.0"

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -46,13 +46,19 @@ final class ViewModel {
 
     init(increment: Signal<Void, Never>, decrement: Signal<Void, Never>) {
 
-        let incrementFeedback = Feedback<Int, Event>(predicate: { $0 < 10}) { _ in
-            increment.map { _ in Event.increment }
-        }
+        let incrementFeedback = Feedback<Int, Event>(
+            condition: { $0 < 10 },
+            whenBecomesTrue: { _ in
+                increment.map { _ in Event.increment }
+            }
+        )
 
-        let decrementFeedback = Feedback<Int, Event>(predicate: { $0 > -10 }) { _ in
-            decrement.map { _ in Event.decrement }
-        }
+        let decrementFeedback = Feedback<Int, Event>(
+            condition: { $0 > -10 },
+            whenBecomesTrue: { _ in
+                decrement.map { _ in Event.decrement }
+            }
+        )
 
         self.state = Property(initial: 0,
                               reduce: ViewModel.reduce,


### PR DESCRIPTION
As discussed in #50 [(this conversation in particular)](https://github.com/babylonhealth/ReactiveFeedback/pull/50#discussion_r367506174), a new "predicate output positive edge triggered" feedback variant shall be introduced to replace `Feedback(predicate:effects:)`. It would be called `Feedback(condition:whenBecomesTrue:)`, with an emphasis on /becoming true/.

Specifically, `condition:whenBecomesTrue:` starts a new effect only when the condition output transitions from false to true. This means the new effect is created against the state at the time of transition, and is never restarted until it has been reset (by the condition going back to false).

Based on observation of RAF practices in our codebase, most users should be able to migrate by simply swapping out `predicate:effects:` with `condition:whenBecomesTrue:`. This is because the former is used mostly in cases yielding one event, e.g. a one-shot loading request. However, if the request _must_ always be reconstructed against the latest state regardless, switching to `condition:whenBecomesTrue:` will breach the expectation.