### PR TITLE
Revert `Property.init` changes to 0.7.0.

### DIFF
--- a/ReactiveFeedback/Property+System.swift
+++ b/ReactiveFeedback/Property+System.swift
@@ -11,11 +11,11 @@ extension Property {
         let state = MutableProperty(initial)
         state <~ SignalProducer.system(
             initial: initial,
+            scheduler: scheduler,
             reduce: reduce,
             feedbacks: feedbacks
         )
         .skip(first: 1)
-        .observe(on: scheduler)
         self.init(capturing: state)
     }
 


### PR DESCRIPTION
The scheduler should be passed to `SignalProducer.system`.