### PR TITLE
Add events to the feedbacks

### DIFF
--- a/Example/SingleStoreExample/RootViewController.swift
+++ b/Example/SingleStoreExample/RootViewController.swift
@@ -20,11 +20,12 @@ final class RootViewController: UITabBarController {
         )
 
         let appFeedbacks: FeedbackLoop<State, Event>.Feedback = FeedbackLoop<State, Event>.Feedback.combine(
-            FeedbackLoop<State, Event>.Feedback.pullback(
-                feedback: Movies.feedback,
-                value: \.movies,
-                event: Event.movies
-            )
+            Movies.feedback
+                .pullback(
+                    value: \.movies,
+                    embed: Event.movies,
+                    extract: { $0.movies }
+                )
         )
         store = Store(
             initial: State(),

--- a/ReactiveFeedback/Floodgate.swift
+++ b/ReactiveFeedback/Floodgate.swift
@@ -11,7 +11,7 @@ final class Floodgate<State, Event>: FeedbackEventConsumer<Event> {
         }
     }
 
-    let (stateDidChange, changeObserver) = Signal<State, Never>.pipe()
+    let (stateDidChange, changeObserver) = Signal<(State, Event?), Never>.pipe()
 
     private let reducerLock = NSLock()
     private var state: State
@@ -33,7 +33,7 @@ final class Floodgate<State, Event>: FeedbackEventConsumer<Event> {
 
         hasStarted = true
 
-        changeObserver.send(value: state)
+        changeObserver.send(value: (state, nil))
         drainEvents()
     }
 
@@ -102,7 +102,7 @@ final class Floodgate<State, Event>: FeedbackEventConsumer<Event> {
 
     private func consume(_ event: Event) {
         reducer(&state, event)
-        changeObserver.send(value: state)
+        changeObserver.send(value: (state, event))
     }
 }
 


### PR DESCRIPTION
Resurrecting old proposal from @inamiy https://github.com/babylonhealth/ReactiveFeedback/pull/41

This is an **additive change** to add `Optional<Event>` argument in `Feedback` so that unnecessary intermediate states will no longer be required.

Event-driven feedback will be useful for following scenarios, without needing to add a new state and then transit (and transit back again):
 
- Logging
- Analytics
- Routing
- Image loader (but not managing its internal states)

This is a change **from Moore model to (kind of) Mealy model** as discussed in https://github.com/Babylonpartners/ReactiveFeedback/pull/32#pullrequestreview-218703551 .

Please note that `reducer` and `feedback` are still in sequence, not parallel.

Also, please note that `Optional<Event>` is used here as a workaround since it requires more breaking changes to minimize into non-optional `Event`.